### PR TITLE
APIサーバのURLを環境変数で定義する

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,10 +5,6 @@ declare module "*.vue" {
   export default component;
 }
 
-interface ImportMetaEnv {
-  readonly VITE_API_SERVER: string;
-}
-
 interface ImportMeta {
-  readonly env: ImportMetaEnv;
+  readonly env: any;
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,3 +4,11 @@ declare module "*.vue" {
   const component: DefineComponent<{}, {}, any>;
   export default component;
 }
+
+interface ImportMetaEnv {
+  readonly VITE_API_SERVER: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -12,8 +12,7 @@ import {
 /**
  * APIサーバーのホストのベースURL。
  */
-export const ServerHost =
-  "https://3421802a-d0a1-4d8d-84e3-9f215c177961.mock.pstmn.io";
+export const ServerHost = import.meta.env.VITE_API_SERVER;
 
 /**
  * API問い合わせ用のfetchヘルパー関数。


### PR DESCRIPTION
**これはタスクのPRではありません**

APIサーバのURLを環境変数で定義することを提案する

現在、Postmanを利用してモックサーバを作成していますが、
PostmanでAPI定義を更新しても、モックは自動的に同期しない
そのため、モックサーバを再構築することが多い
そして、モックサーバを再構築するたびに、新しいURLが発行される

モックサーバのURLを更新するたびにコミットするのは重複とミスが発生する
そのため、Viteの機能を利用して、
APIサーバのURLを環境変数と.envファイルから取得することを提案する。

PRをマージすると、`.env`ファイルを作成することとviteを利用して開発することは必須になります
`.env`ファイルには`VITE_API_SERVER=<API_SERVER_URL>`でサーバのURLを定義することが必須になります

そうすると、サーバのURLが変更しても`.env`ファイルを編集するだけ